### PR TITLE
Update Micro Celery endpoints

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,10 +66,12 @@ Send tasks
 
 .. code:: python
 
-    >>> from micro.api.endpoints import plugins, run
+    >>> from micro.api.endpoints import Requests
     >>>
-    >>> plugins.delay().wait()
+    >>> req = Requests(BROKER_URL, QUEUE_NAME)
+    >>>
+    >>> req.plugins.delay().wait()
     {'Example plugin': 'A very simple example plugin'}
     >>>
-    >>> run.delay("Example plugin", name="Micro").wait()
+    >>> req.run.delay("Example plugin", name="Micro").wait()
     'Hello Micro!!!'

--- a/micro/api/endpoints.py
+++ b/micro/api/endpoints.py
@@ -1,33 +1,27 @@
-import os
 from celery import Celery
 
-BROKER_URL = os.environ.get("MICRO_BROKER_URL")
-QUEUE = os.environ.get("MICRO_QUEUE")
-
-if not BROKER_URL:
-    raise RuntimeError("No broker URL set")
-
-if not QUEUE:
-    raise RuntimeError("No queue set")
-
-app = Celery("Micro", broker=BROKER_URL, backend="rpc://")
+app = Celery("Micro", backend="rpc://")
 
 
-@app.task(name="Micro.plugins", queue=QUEUE)
-def plugins():
-    pass
+class Requests:
+    def __init__(self, broker, queue):
+        app.conf.update(
+            broker_url=broker,
+            task_routes={"Micro.*": {"queue": queue}}
+        )
 
+    @app.task(name="Micro.plugins")
+    def plugins():
+        pass
 
-@app.task(name="Micro.info", queue=QUEUE)
-def info(name):
-    pass
+    @app.task(name="Micro.info")
+    def info(name):
+        pass
 
+    @app.task(name="Micro.help")
+    def help(name):
+        pass
 
-@app.task(name="Micro.help", queue=QUEUE)
-def help(name):
-    pass
-
-
-@app.task(name="Micro.run", queue=QUEUE)
-def run(plugin_name, **kwargs):
-    pass
+    @app.task(name="Micro.run")
+    def run(plugin_name, **kwargs):
+        pass

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
 setup(
     name='Micro-dev',
 
-    version='1.0.1',
+    version='2.0.0',
 
     description='Library to create microservices for Micro',
     long_description=long_description,


### PR DESCRIPTION
Now, the Celery endpoints are methods of the new `Requests` class, so you need to instance it giving the `broker_url` and the `queue` name arguments in order to do it